### PR TITLE
check socket status before shutdown

### DIFF
--- a/mysensors/mysensors.py
+++ b/mysensors/mysensors.py
@@ -544,7 +544,12 @@ class TCPGateway(Gateway, threading.Thread):
         if not self.sock:
             return
         _LOGGER.info('Closing socket at %s.', self.server_address)
-        self.sock.shutdown(socket.SHUT_WR)
+      
+        try:
+            self.sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            _LOGGER.error('Failed to shutdown socket at %s.', self.server_address)
+      
         self.sock.close()
         self.sock = None
         _LOGGER.info('Socket closed at %s.', self.server_address)


### PR DESCRIPTION
if MySensors TCPGateway socket is not available during homeassistant execution when it is reachable again the following error occours:

```
Oct 29 11:02:37 raspberrypi hass[14753]: INFO:mysensors.mysensors:Closing socket at ('127.0.0.1', 5003).
Oct 29 11:02:44 raspberrypi hass[14753]: Exception in thread Thread-5:
Oct 29 11:02:44 raspberrypi hass[14753]: Traceback (most recent call last):
Oct 29 11:02:44 raspberrypi hass[14753]: File "/home/homeassistant/.homeassistant/deps/mysensors/mysensors.py", line 618, in send
Oct 29 11:02:44 raspberrypi hass[14753]: self.sock.sendall(message.encode())
Oct 29 11:02:44 raspberrypi hass[14753]: BrokenPipeError: [Errno 32] Broken pipe
Oct 29 11:02:44 raspberrypi hass[14753]: During handling of the above exception, another exception occurred:
Oct 29 11:02:44 raspberrypi hass[14753]: Traceback (most recent call last):
Oct 29 11:02:44 raspberrypi hass[14753]: File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
Oct 29 11:02:44 raspberrypi hass[14753]: self.run()
Oct 29 11:02:44 raspberrypi hass[14753]: File "/home/homeassistant/.homeassistant/deps/mysensors/mysensors.py", line 640, in run
Oct 29 11:02:44 raspberrypi hass[14753]: self.send(response)
Oct 29 11:02:44 raspberrypi hass[14753]: File "/home/homeassistant/.homeassistant/deps/mysensors/mysensors.py", line 622, in send
Oct 29 11:02:44 raspberrypi hass[14753]: self.disconnect()
Oct 29 11:02:44 raspberrypi hass[14753]: File "/home/homeassistant/.homeassistant/deps/mysensors/mysensors.py", line 547, in disconnect
Oct 29 11:02:44 raspberrypi hass[14753]: self.sock.shutdown(socket.SHUT_WR)
Oct 29 11:02:44 raspberrypi hass[14753]: OSError: [Errno 107] Transport endpoint is not connected
```

to avoid this problem a try/except on socket is needed for shutdown
